### PR TITLE
Added 'contentTransferEncoding' attribute for attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ Attachment object consists of the following properties:
   * **filename** - filename to be reported as the name of the attached file, use of unicode is allowed
   * **cid** - optional content id for using inline images in HTML message source
   * **content** - String, Buffer or a Stream contents for the attachment
-  * **encoding** - If set and `content` is string, then encodes the content to a Buffer using the specified encoding. Example values: `base64`, `hex`, `binary` etc. Useful if you want to use binary attachments in a JSON formatted e-mail object.
+  * **encoding** - If set and `content` is string, then encodes the content to a Buffer using the specified encoding. Example values: `base64`, `hex`, `binary` etc. Useful if you want to use binary attachments in a JSON formatted e-mail object
   * **path** - path to a file or an URL (data uris are allowed as well) if you want to stream the file instead of including it (better for larger attachments)
   * **contentType** - optional content type for the attachment, if not set will be derived from the `filename` property
+  * **contentTransferEncoding** - optional transfer encoding for the attachment, if not set it will be derived from the `contentType` property. Example values: `quoted-printable`, `base64`
   * **contentDisposition** - optional content disposition type for the attachment, defaults to 'attachment'
 
 Attachments can be added as many as you want.

--- a/lib/mailcomposer.js
+++ b/lib/mailcomposer.js
@@ -209,10 +209,12 @@ MailComposer.prototype._createContentNode = function(parentNode, element) {
         node.setHeader('Content-Id', '<' + element.cid.replace(/[<>]/g, '') + '>');
     }
 
-    if (this.mail.encoding && /^text\//i.test(element.contentType)) {
+	if (element.contentTransferEncoding) {
+		node.setHeader('Content-Transfer-Encoding', element.contentTransferEncoding);
+    } else if (this.mail.encoding && /^text\//i.test(element.contentType)) {
         node.setHeader('Content-Transfer-Encoding', this.mail.encoding);
     }
-
+	
     if (!/^text\//i.test(element.contentType) || element.contentDisposition) {
         node.setHeader('Content-Disposition', element.contentDisposition || 'attachment');
     }
@@ -243,7 +245,8 @@ MailComposer.prototype._getAttachments = function(findRelated) {
         data = {
             contentType: attachment.contentType ||
                 libmime.detectMimeType(attachment.filename || attachment.path || attachment.href || 'bin'),
-            contentDisposition: attachment.contentDisposition || 'attachment'
+            contentDisposition: attachment.contentDisposition || 'attachment',
+			contentTransferEncoding: attachment.contentTransferEncoding
         };
 
         if (attachment.filename) {


### PR DESCRIPTION
I created the `contentTransferEncoding` parameter for attachments. You can use it to override the automatic transfer encoding detection currently dependent by content-type (and by `encoding` attribute in some cases)

I did this because I need to set **quoted-printable** for attachments with content type **application/soap+xml**, and so now I can do this:

```javascript
...
attachments: [{
 filename: 'myfile.xml',
 path: '/home/neurone/file.xml',
 contentType: 'application/soap+xml; charset="utf-8"',
 contentTransferEncoding: 'quoted-printable'
}],
...
```